### PR TITLE
get_active_ordersの2回目以降の呼び出しで通貨ペアを変更できないバグを修正

### DIFF
--- a/python_bitbankcc/private_api.py
+++ b/python_bitbankcc/private_api.py
@@ -79,7 +79,9 @@ class bitbankcc_private(object):
             'order_id': order_id
         })
     
-    def get_active_orders(self, pair, options={}):
+    def get_active_orders(self, pair, options=None):
+        if options is None:
+            options = {}
         if not 'pair' in options:
             options['pair'] = pair
         return self._get_query('/user/spot/active_orders?', options)


### PR DESCRIPTION
下記のように2回目以降の呼び出しで通貨ペアを変更した場合でも、1回目に指定した通貨ペアがそのまま使われていました。
Pythonのデフォルト引数に指定した値が作成されるのは定義時のみなので、破壊的変更を行うと、次回の呼び出しでも変更がそのままとなってしまいます。

```
>>> import python_bitbankcc
>>> API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
>>> API_SECRET = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
>>> prv = python_bitbankcc.private(API_KEY, API_SECRET)
>>> prv.get_active_orders('btc_jpy')
GET: /v1/user/spot/active_orders?pair=btc_jpy
{u'orders': []}
>>> prv.get_active_orders('mona_jpy')
GET: /v1/user/spot/active_orders?pair=btc_jpy
{u'orders': []}
```