### PR TITLE
api.bitbank.ccとpublic.bitbank.ccのend_pointの向き先を変更できるように修正

### DIFF
--- a/python_bitbankcc/private_api.py
+++ b/python_bitbankcc/private_api.py
@@ -54,8 +54,8 @@ def make_header(query_data, api_key, api_secret):
 
 class bitbankcc_private(object):
     
-    def __init__(self, api_key, api_secret):
-        self.end_point = 'https://api.bitbank.cc/v1'
+    def __init__(self, api_key, api_secret, end_point='https://api.bitbank.cc/v1'):
+        self.end_point = end_point
         self.api_key = api_key
         self.api_secret = api_secret
     

--- a/python_bitbankcc/public_api.py
+++ b/python_bitbankcc/public_api.py
@@ -34,8 +34,8 @@ logger = getLogger(__name__)
 
 class bitbankcc_public(object):
     
-    def __init__(self):
-        self.end_point = 'https://public.bitbank.cc'
+    def __init__(self, end_point='https://public.bitbank.cc'):
+        self.end_point = end_point
     
     def _query(self, query_url):
         with contextlib.closing(requests.get(query_url)) as response:


### PR DESCRIPTION
以下のようにクラスを初期化することでlocalなどの別環境へリクエストを送れるように変更を加えました
```python
import python_bitbankcc
import os

API_KEY = os.environ['BITBANK_API_KEY']
API_SECRET = os.environ['BITBANK_API_SECRET']

pub = python_bitbankcc.public("https://hoge-public.bitbank.cc")
prv = python_bitbankcc.private(API_KEY, API_SECRET,"https://hoge-api.bitbank.cc/v1")
```