### PR TITLE
fix: add 409 or 429 error handling

### DIFF
--- a/python_bitbankcc/private_api.py
+++ b/python_bitbankcc/private_api.py
@@ -70,11 +70,8 @@ class bitbankcc_private(object):
         headers = make_header(data, self.api_key, self.api_secret)
         uri = self.end_point + path + urlencode(query)
         with contextlib.closing(requests.get(uri, headers=headers)) as response:
-            try:
-                response.raise_for_status()
-                return error_parser(try_json_parse(response, logger))
-            except requests.exceptions.RequestException as e:
-                raise Exception(e)
+            response.raise_for_status()
+            return error_parser(try_json_parse(response, logger))
 
     def _post_query(self, path, query):
         data = json.dumps(query)
@@ -82,11 +79,8 @@ class bitbankcc_private(object):
         headers = make_header(data, self.api_key, self.api_secret)
         uri = self.end_point + path
         with contextlib.closing(requests.post(uri, data=data, headers=headers)) as response:
-            try:
-                response.raise_for_status()
-                return error_parser(try_json_parse(response, logger))
-            except requests.exceptions.RequestException as e:
-                raise Exception(e)
+            response.raise_for_status()
+            return error_parser(try_json_parse(response, logger))
 
     def get_asset(self):
         return self._get_query('/user/assets', {})

--- a/python_bitbankcc/private_api.py
+++ b/python_bitbankcc/private_api.py
@@ -106,19 +106,19 @@ class bitbankcc_private(object):
             'side': side,
             'type': order_type,
             'post_only': post_only
-        }, throw_too_many_error)
+        }, throw_too_many_request_error)
 
     def cancel_order(self, pair, order_id):
         return self._post_query('/user/spot/cancel_order', {
             'pair': pair,
             'order_id': order_id
-        }, throw_too_many_error)
+        }, throw_too_many_request_error)
 
     def cancel_orders(self, pair, order_ids):
         return self._post_query('/user/spot/cancel_orders', {
             'pair': pair,
             'order_ids': order_ids
-        }, throw_too_many_error)
+        }, throw_too_many_request_error)
 
     def get_orders_info(self, pair, order_ids):
         return self._post_query('/user/spot/orders_info', {

--- a/python_bitbankcc/public_api.py
+++ b/python_bitbankcc/public_api.py
@@ -39,6 +39,7 @@ class bitbankcc_public(object):
     
     def _query(self, query_url):
         with contextlib.closing(requests.get(query_url)) as response:
+            response.raise_for_status()
             return error_parser(try_json_parse(response, logger))
     
     def get_ticker(self, pair):

--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -25,12 +25,6 @@
 
 from requests.models import Response
 
-def throw_too_many_request_error(response: Response, logger) -> Response:
-    if response.status_code == 409 or response.status_code == 429:
-        logger.debug('エラーコード: ' + str(response.status_code) + ' 内容: ' + ERROR_CODES['70011'])
-        raise Exception(ERROR_CODES['70011'])
-    return response
-
 def try_json_parse(response, logger):
     try:
         return response.json()

--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -28,7 +28,7 @@ from requests.models import Response
 def throw_too_many_request_error(response: Response, logger) -> Response:
     if response.status_code == 409 or response.status_code == 429:
         logger.debug('エラーコード: ' + str(response.status_code) + ' 内容: ' + ERROR_CODES['70011'])
-        raise Exception(ERROR_CODES['7011'])
+        raise Exception(ERROR_CODES['70011'])
     return response
 
 def try_json_parse(response, logger):

--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -23,8 +23,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from requests.models import Response
-
 def try_json_parse(response, logger):
     try:
         return response.json()

--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -2,19 +2,19 @@
 # -*- coding: utf-8 -*-
 #
 # MIT License
-# 
+#
 # Copyright (c) 2017 bitbank, inc. (ビットバンク株式会社)
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,6 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+from requests.models import Response
+
+def throw_too_many_request_error(response: Response, logger) -> Response:
+    if response.status_code == 409 or response.status_code == 429:
+        logger.debug('エラーコード: ' + str(response.status_code) + ' 内容: ' + ERROR_CODES['70011'])
+        raise Exception(ERROR_CODES['7011'])
+    return response
 
 def try_json_parse(response, logger):
     try:


### PR DESCRIPTION
### When 429 error

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 188, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/local/Cellar/python@3.9/3.9.4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/Users/koheiiizuka/hello.py", line 42, in <module>
    value = prv.cancel_order(
  File "/Users/koheiiizuka/python-bitbankcc/python_bitbankcc/private_api.py", line 112, in cancel_order
    return self._post_query('/user/spot/cancel_order', {
  File "/Users/koheiiizuka/python-bitbankcc/python_bitbankcc/private_api.py", line 82, in _post_query
    return error_parser(try_json_parse(fn(response, logger), logger))
  File "/Users/koheiiizuka/python-bitbankcc/python_bitbankcc/utils.py", line 32, in throw_too_many_request_error
    raise Exception(ERROR_CODES['70011'])
Exception: ただいまリクエストが混雑してます。しばらく時間を空けてから再度リクエストをお願いします
```