### PR TITLE
Creating a custom exception class to differentiate API client issues

### DIFF
--- a/python_bitbankcc/__init__.py
+++ b/python_bitbankcc/__init__.py
@@ -25,3 +25,4 @@
 
 from .public_api import bitbankcc_public as public
 from .private_api import bitbankcc_private as private
+from .utils import BitbankClientException

--- a/python_bitbankcc/__init__.py
+++ b/python_bitbankcc/__init__.py
@@ -25,4 +25,4 @@
 
 from .public_api import bitbankcc_public as public
 from .private_api import bitbankcc_private as private
-from .utils import BitbankClientException
+from .utils import BitbankClientError

--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -23,7 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-class BitbankClientException(Exception):
+class BitbankClientError(Exception):
     def __init__(self, error_message=None):
         self.msg = error_message 
     def __str__(self):
@@ -34,7 +34,7 @@ def try_json_parse(response, logger):
         return response.json()
     except:
         logger.debug('Invalid JSON: ' + repr(response.content))
-        raise BitbankClientException('不正なJSONデータがサーバーから返ってきました。お問い合わせください')
+        raise BitbankClientError('不正なJSONデータがサーバーから返ってきました。お問い合わせください')
 
 def error_parser(json_dict):
     if json_dict['success'] == 1:
@@ -43,7 +43,7 @@ def error_parser(json_dict):
         code = str(json_dict['data']['code'])
         contents = ERROR_CODES[code] if code in ERROR_CODES else '不明なエラーです。サポートにお問い合わせ下さい'
         message = 'エラーコード: ' + code + ' 内容: ' + contents
-        raise BitbankClientException(message)
+        raise BitbankClientError(message)
 
 ERROR_CODES = {
     '10000': 'URLが存在しません',

--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -23,7 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-class BitbankException(Exception):
+class BitbankClientException(Exception):
     def __init__(self, error_message=None):
         self.msg = error_message 
     def __str__(self):
@@ -34,7 +34,7 @@ def try_json_parse(response, logger):
         return response.json()
     except:
         logger.debug('Invalid JSON: ' + repr(response.content))
-        raise BitbankException('不正なJSONデータがサーバーから返ってきました。お問い合わせください')
+        raise BitbankClientException('不正なJSONデータがサーバーから返ってきました。お問い合わせください')
 
 def error_parser(json_dict):
     if json_dict['success'] == 1:
@@ -43,7 +43,7 @@ def error_parser(json_dict):
         code = str(json_dict['data']['code'])
         contents = ERROR_CODES[code] if code in ERROR_CODES else '不明なエラーです。サポートにお問い合わせ下さい'
         message = 'エラーコード: ' + code + ' 内容: ' + contents
-        raise BitbankException(message)
+        raise BitbankClientException(message)
 
 ERROR_CODES = {
     '10000': 'URLが存在しません',

--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -23,12 +23,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+class BitbankException(Exception):
+    def __init__(self, error_message=None):
+        self.msg = error_message 
+    def __str__(self):
+        return self.msg
+
 def try_json_parse(response, logger):
     try:
         return response.json()
     except:
         logger.debug('Invalid JSON: ' + repr(response.content))
-        raise Exception('不正なJSONデータがサーバーから返ってきました。お問い合わせください')
+        raise BitbankException('不正なJSONデータがサーバーから返ってきました。お問い合わせください')
 
 def error_parser(json_dict):
     if json_dict['success'] == 1:
@@ -37,7 +43,7 @@ def error_parser(json_dict):
         code = str(json_dict['data']['code'])
         contents = ERROR_CODES[code] if code in ERROR_CODES else '不明なエラーです。サポートにお問い合わせ下さい'
         message = 'エラーコード: ' + code + ' 内容: ' + contents
-        raise Exception(message)
+        raise BitbankException(message)
 
 ERROR_CODES = {
     '10000': 'URLが存在しません',


### PR DESCRIPTION
I have noticed that Bitbank API client has been issuing default blanket Exception to upstream.
This is too wide of a Exception and if user wants to differentiate between built-in and Bitbank originated exception, it is impossible to do so.
This addition helps user to import the custom exception and catch it accordingly.