### PR TITLE
feat: リクエストタイムアウトの追加（応答がない場合の無期限ブロックを防止）

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ API_SECRET = os.environ['BITBANK_API_SECRET']
 config = {
     'auth_method': 'request_time',
     'time_window': 5000,
+    'timeout': 30, # リクエストタイムアウト秒数（省略時 30、None でタイムアウトなし）
 }
 prv = python_bitbankcc.private(API_KEY, API_SECRET, config=config)
 

--- a/python_bitbankcc/private_api.py
+++ b/python_bitbankcc/private_api.py
@@ -72,6 +72,7 @@ default_config = {
     'end_point':'https://api.bitbank.cc/v1',
     'auth_method': 'request_time',
     'time_window': 5000,
+    'timeout': 30,
 }
 
 class bitbankcc_private(object):
@@ -83,6 +84,8 @@ class bitbankcc_private(object):
         self.api_secret = api_secret
         self.auth_method = config['auth_method'] if 'auth_method' in config else 'request_time'
         self.time_window = config['time_window'] if 'time_window' in config else 5000
+        # None を指定するとタイムアウトなし（従来の挙動）
+        self.timeout = config['timeout'] if 'timeout' in config else 30
 
     def _get_query(self, path, query):
         if len(query) > 0 and '?' not in path :
@@ -93,7 +96,7 @@ class bitbankcc_private(object):
             if self.auth_method == 'request_time' \
             else make_nonce_header(data, self.api_key, self.api_secret)
         uri = self.end_point + path + urlencode(query)
-        with contextlib.closing(requests.get(uri, headers=headers)) as response:
+        with contextlib.closing(requests.get(uri, headers=headers, timeout=self.timeout)) as response:
             response.raise_for_status()
             return error_parser(try_json_parse(response, logger))
 
@@ -104,7 +107,7 @@ class bitbankcc_private(object):
             if self.auth_method == 'request_time' \
             else make_nonce_header(data, self.api_key, self.api_secret)
         uri = self.end_point + path
-        with contextlib.closing(requests.post(uri, data=data, headers=headers)) as response:
+        with contextlib.closing(requests.post(uri, data=data, headers=headers, timeout=self.timeout)) as response:
             response.raise_for_status()
             return error_parser(try_json_parse(response, logger))
 

--- a/python_bitbankcc/public_api.py
+++ b/python_bitbankcc/public_api.py
@@ -34,11 +34,13 @@ logger = getLogger(__name__)
 
 class bitbankcc_public(object):
 
-    def __init__(self, end_point='https://public.bitbank.cc'):
+    def __init__(self, end_point='https://public.bitbank.cc', timeout=30):
         self.end_point = end_point
+        # None を指定するとタイムアウトなし（従来の挙動）
+        self.timeout = timeout
 
     def _query(self, query_url):
-        with contextlib.closing(requests.get(query_url)) as response:
+        with contextlib.closing(requests.get(query_url, timeout=self.timeout)) as response:
             response.raise_for_status()
             return error_parser(try_json_parse(response, logger))
 


### PR DESCRIPTION
## 概要

`requests.get` / `requests.post` に `timeout` が指定されていないため、サーバーが応答しない場合にリクエストが無期限にブロックします。自動売買プログラム等に組み込んだ際、注文状態が不明のまま処理が停止するリスクがあるため、タイムアウトを追加しました。

## 変更内容

- **private API**: `config` の `timeout` キーで指定可能（省略時 30 秒）
- **public API**: コンストラクタの `timeout` 引数で指定可能（省略時 30 秒）
- いずれも `None` を指定すると従来どおりタイムアウトなし
- README の config 例に `timeout` の説明を追記

## 互換性への影響

タイムアウト時は `requests.exceptions.Timeout` が送出されます。従来は無限に待機していた場面で新たに例外が発生し得るため、完全な従来挙動が必要な場合は `timeout: None` を指定してください。デフォルト値（30 秒）は、正常なレスポンスには十分長く、ハングを検知するには十分短い値として選定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)