### PR TITLE
fix: end_point コンストラクタ引数が無視される問題の修正

### DIFF
--- a/python_bitbankcc/private_api.py
+++ b/python_bitbankcc/private_api.py
@@ -76,8 +76,11 @@ default_config = {
 
 class bitbankcc_private(object):
 
-    def __init__(self, api_key, api_secret, end_point='https://api.bitbank.cc/v1', config=default_config):
-        self.end_point = config['end_point'] if 'end_point' in config else 'https://api.bitbank.cc/v1'
+    def __init__(self, api_key, api_secret, end_point='https://api.bitbank.cc/v1', config=None):
+        if config is None:
+            config = {}
+        # config に 'end_point' があればそちらを優先し、なければ end_point 引数を使う
+        self.end_point = config['end_point'] if 'end_point' in config else end_point
         self.path_stub = get_path_from_end_point(self.end_point)
         self.api_key = api_key
         self.api_secret = api_secret


### PR DESCRIPTION
## 概要

`bitbankcc_private.__init__` の `end_point` 引数は現在使用されておらず、`config['end_point']` のみが参照されています。そのため `private(KEY, SECRET, 'https://example.com/v1')` のようにエンドポイントを引数で指定しても、実際には本番 API（`https://api.bitbank.cc/v1`）に接続されます。

## 変更内容

- `config` に `end_point` がある場合は従来どおり `config` を優先
- `config` に `end_point` がない場合は `end_point` 引数を使用
- あわせてミュータブルなデフォルト引数（`config=default_config`）を `config=None` に変更し、共有辞書の意図しない書き換えを防止

## 互換性への影響

既存の呼び出し（`config` で `end_point` を指定、または引数を省略）の挙動は変わりません。`config` と引数の両方で指定された場合に `config` を優先するのは、従来動いていたコードの挙動を維持するためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)