### PR TITLE
fix: try_json_parse で JSON パースエラーのみを捕捉するよう修正

### DIFF
--- a/python_bitbankcc/utils.py
+++ b/python_bitbankcc/utils.py
@@ -32,7 +32,7 @@ class BitbankClientError(Exception):
 def try_json_parse(response, logger):
     try:
         return response.json()
-    except:
+    except ValueError:
         logger.debug('Invalid JSON: ' + repr(response.content))
         raise BitbankClientError('不正なJSONデータがサーバーから返ってきました。お問い合わせください')
 


### PR DESCRIPTION
## 概要

`utils.py` の `try_json_parse` は裸の `except:` を使用しているため、`KeyboardInterrupt` や `SystemExit` を含むすべての例外を「不正な JSON」エラーとして変換してしまい、障害時の原因特定を困難にします。

## 変更内容

捕捉対象を `ValueError` に限定しました。`response.json()` が JSON パース失敗時に送出する `JSONDecodeError`（`json.JSONDecodeError` / `simplejson.JSONDecodeError`）はいずれも `ValueError` のサブクラスであるため、正常系・異常系の従来挙動は変わりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)